### PR TITLE
Enable Corepack in createRelease action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Enable Corepack
-        run: corepack enable
+          corepack: true
 
       - name: Install dependencies
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3


### PR DESCRIPTION
Adds corepack enable step before installing dependencies in the createRelease job to ensure the correct yarn version is used, matching the pattern used in the tests workflow.