### PR TITLE
Enable Corepack in createRelease action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,7 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Enable Corepack
-        run: corepack enable
+          corepack: true
 
       - name: Install dependencies
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,14 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         name: Checkout repository
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
         name: Use Node.js 20.x
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-          corepack: true
 
       - name: Install dependencies
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3


### PR DESCRIPTION
Adds corepack enable step before setup-node in the createRelease job to ensure the correct yarn version (4.9.2) is used as specified in package.json's packageManager field.

This matches the pattern used in tests.yml and fixes the error where yarn was falling back to the global version (1.22.22) instead of the project's specified version.