### PR TITLE
Enable Corepack in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         name: Checkout repository
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
         name: Use Node.js 20.x
         with:

--- a/.github/workflows/updateSDKQueries.yml
+++ b/.github/workflows/updateSDKQueries.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           path: node-client
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Adds corepack enable step before setup-node in the publish job to ensure the correct yarn version (4.9.2) is used as specified in package.json's packageManager field.

This matches the pattern used in tests.yml and release.yml workflows and prevents yarn from falling back to the global version.