### PR TITLE
Fix lodash prototype pollution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prepublishOnly": "yarn build"
   },
   "resolutions": {
+    "lodash": "4.17.23",
     "cross-spawn": "7.0.5",
     "dset": "3.1.4",
     "micromatch": "4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6528,10 +6528,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:~4.17.0":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+"lodash@npm:4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add resolution to pin lodash to 4.17.23
- Fixes prototype pollution vulnerability in `_.unset` and `_.omit` functions

## Test plan
- [x] `yarn` succeeds
- [x] `yarn typecheck` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)