### PR TITLE
Fix Dependabot security alert for tar

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "vite": "6.4.1",
     "@babel/runtime": "7.27.1",
     "@babel/helpers": "7.27.1",
-    "tar": "7.5.4",
+    "tar": "7.5.7",
     "qs": "6.14.1",
     "brace-expansion@^1.1.7": "1.1.12",
     "brace-expansion@^2.0.1": "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8587,16 +8587,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.4":
-  version: 7.5.4
-  resolution: "tar@npm:7.5.4"
+"tar@npm:7.5.7":
+  version: 7.5.7
+  resolution: "tar@npm:7.5.7"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/9e744b10a32cea651430ec541ec9326d5d4b09381ab4cecf152f9a35069528510c55517fc70d2996c3d07b16370c66205f1b52dd260b6cd1d1dfbc8940050920
+  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Update `tar` resolution from 7.5.4 to 7.5.7 (high: arbitrary file creation via hardlink path traversal)

Resolves Dependabot alert #48.

## Test plan

- [ ] Verify yarn install completes without errors
- [ ] Verify build completes successfully
- [ ] Verify tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)