### PR TITLE
Fix Dependabot alert #54: bump tar to 7.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "vite": "6.4.1",
     "@babel/runtime": "7.27.1",
     "@babel/helpers": "7.27.1",
-    "tar": "7.5.7",
+    "tar": "7.5.8",
     "qs": "6.14.2",
     "brace-expansion@^1.1.7": "1.1.12",
     "brace-expansion@^2.0.1": "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8587,16 +8587,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.7":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+"tar@npm:7.5.8":
+  version: 7.5.8
+  resolution: "tar@npm:7.5.8"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
+  checksum: 10c0/8569db1b49f5d72084cbdcad9d2b39fcc115993186455aa052c1da0a2739b20e2d94af6a23609fc25d3ae63c9fed8b159f3b1d16b699e9ef25e3b8464603d153
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #54 (high severity): arbitrary file read/write via hardlink target escape through symlink chain in node-tar
- Bumped `tar` resolution from `7.5.7` to `7.5.8`
- All consumers of `tar` are dev/build tooling only (cacache, node-gyp) — no production impact

## Test plan
- [x] `yarn` resolves successfully
- [x] `yarn why tar` confirms updated version
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)