### PR TITLE
Derive npm dist-tag from package major in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,20 @@ jobs:
           max_attempts: 2
           command: yarn
 
-      - run: npm publish --access public
+      - name: Determine npm dist-tag
+        id: dist-tag
+        run: |
+          VERSION="$(npm pkg get version | tr -d '\"')"
+          MAJOR="${VERSION%%.*}"
+          LATEST_MAJOR="$(npm view @fragment-dev/node-client version 2>/dev/null | cut -d. -f1)"
+          if [ -n "$LATEST_MAJOR" ] && [ "$MAJOR" -lt "$LATEST_MAJOR" ]; then
+            TAG="v$MAJOR"
+          else
+            TAG="latest"
+          fi
+          echo "Publishing $VERSION under dist-tag $TAG"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - run: npm publish --access public --tag ${{ steps.dist-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`publish.yml` ran a bare `npm publish`, which always moves the `latest` dist-tag to whatever version is being published.

That is wrong for maintenance releases on an older major: publishing `1.5.1` from the v1 line would point `latest` at it, pulling every `npm install @fragment-dev/node-client` back from 2.1.0 to 1.5.1.

This compares the package major against the current `latest` major and publishes older majors under a `v<major>` tag instead.

Verified against the live registry:

| package version | resolved dist-tag |
|---|---|
| 1.5.1 | `v1` |
| 2.2.0 | `latest` |
| 3.0.0 | `latest` |

Needed by the pending v1.5.1 backport release (branch `release/v1.5.1`).